### PR TITLE
refactor: replace PrismaService with TaskRepository

### DIFF
--- a/src/tasks/repositories/task.repository.ts
+++ b/src/tasks/repositories/task.repository.ts
@@ -1,0 +1,120 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { Prisma, Task } from '@prisma/client';
+
+@Injectable()
+export class TaskRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async findTasksByWeekPlan(weekPlanId: string) {
+    return this.prisma.task.findMany({
+      where: { weekPlanId },
+      include: {
+        category: {
+          select: { name: true },
+        },
+        weekPlan: true,
+      },
+    });
+  }
+
+  async findLastPosition(weekPlanId: string, day: number): Promise<number> {
+    const tasks = await this.prisma.task.findMany({
+      where: {
+        weekPlanId,
+        day,
+        isArchived: false,
+      },
+      select: { position: true },
+      orderBy: { position: 'desc' },
+      take: 1,
+    });
+    return tasks.length > 0 ? tasks[0].position + 1000 : 1000;
+  }
+
+  async createTask(data: Prisma.TaskCreateInput) {
+    return this.prisma.task.create({
+      data,
+      include: {
+        category: {
+          select: { name: true },
+        },
+      },
+    });
+  }
+
+  async findTaskById(id: string) {
+    return this.prisma.task.findUnique({
+      where: { id },
+      include: {
+        category: {
+          select: { name: true },
+        },
+      },
+    });
+  }
+
+  async updateTask(id: string, data: Prisma.TaskUpdateInput) {
+    return this.prisma.task.update({
+      where: { id },
+      data,
+      include: {
+        category: {
+          select: { name: true },
+        },
+      },
+    });
+  }
+
+  async deleteTask(id: string) {
+    return this.prisma.task.delete({
+      where: { id },
+      include: {
+        category: {
+          select: { name: true },
+        },
+      },
+    });
+  }
+
+  async findArchivedTasks(userId: string) {
+    return this.prisma.task.findMany({
+      where: {
+        isArchived: true,
+        category: {
+          userId: userId,
+        },
+      },
+      include: {
+        category: {
+          select: { name: true },
+        },
+      },
+      orderBy: {
+        archivedAt: 'desc',
+      },
+    });
+  }
+
+  async findAllNonArchivedTasks() {
+    return this.prisma.task.findMany({
+      where: { isArchived: false },
+      orderBy: [{ weekPlanId: 'asc' }, { day: 'asc' }, { position: 'asc' }],
+    });
+  }
+
+  async updateTasksPositions(tasks: { id: string; position: number }[]) {
+    return Promise.all(
+      tasks.map(({ id, position }) =>
+        this.prisma.task.update({
+          where: { id },
+          data: { position },
+        }),
+      ),
+    );
+  }
+
+  async transaction<T>(fn: (tx: Prisma.TransactionClient) => Promise<T>) {
+    return this.prisma.$transaction(fn);
+  }
+}

--- a/src/tasks/tasks.module.ts
+++ b/src/tasks/tasks.module.ts
@@ -1,12 +1,14 @@
 import { Module } from '@nestjs/common';
-import { TasksController } from './tasks.controller';
 import { TasksService } from './tasks.service';
-import { CategoriesModule } from '../categories/categories.module';
+import { TasksController } from './tasks.controller';
+import { TaskRepository } from './repositories/task.repository';
 import { WebsocketModule } from 'src/websocket/websocket.module';
+import { CategoriesModule } from '../categories/categories.module';
 
 @Module({
-  imports: [CategoriesModule, WebsocketModule],
+  imports: [WebsocketModule, CategoriesModule],
   controllers: [TasksController],
-  providers: [TasksService],
+  providers: [TasksService, TaskRepository],
+  exports: [TasksService],
 })
 export class TasksModule {}

--- a/src/tasks/tasks.service.ts
+++ b/src/tasks/tasks.service.ts
@@ -4,7 +4,6 @@ import {
   Injectable,
   InternalServerErrorException,
 } from '@nestjs/common';
-import { PrismaService } from 'src/prisma/prisma.service';
 import { CreateTaskDto, UpdateTaskDto } from './dto';
 import { WebsocketGateway } from 'src/websocket/websocket.gateway';
 import { Prisma, Task } from '@prisma/client';
@@ -16,11 +15,12 @@ import {
 } from '../common/exceptions/task.exceptions';
 import { MoveTaskDto } from './dto/move-task.dto';
 import { CategoriesService } from '../categories/categories.service';
+import { TaskRepository } from './repositories/task.repository';
 
 @Injectable()
 export class TasksService {
   constructor(
-    private readonly prisma: PrismaService,
+    private readonly taskRepository: TaskRepository,
     private readonly websocket: WebsocketGateway,
     private readonly categoriesService: CategoriesService,
   ) {}
@@ -29,67 +29,52 @@ export class TasksService {
     weekPlanId: string,
     day: number,
   ): Promise<number> {
-    const tasks = await this.prisma.task.findMany({
-      where: {
-        weekPlanId,
-        day,
-        isArchived: false,
-      },
-      select: { position: true },
-      orderBy: { position: 'desc' },
-      take: 1,
-    });
+    const tasks = await this.taskRepository.transaction((tx) =>
+      tx.task.findMany({
+        where: {
+          weekPlanId,
+          day,
+          isArchived: false,
+        },
+        select: { position: true },
+        orderBy: { position: 'desc' },
+        take: 1,
+      }),
+    );
     return tasks.length > 0 ? tasks[0].position + 1000 : 1000;
   }
 
   async createTask(weekPlanId: string, data: CreateTaskDto) {
     try {
-      return await this.prisma.$transaction(async (tx) => {
+      return await this.taskRepository.transaction(async (tx) => {
         const [weekPlan, category] = await Promise.all([
-          tx.weekPlan.findUnique({
-            where: { id: weekPlanId },
-          }),
+          tx.weekPlan.findUnique({ where: { id: weekPlanId } }),
           data.categoryId
-            ? tx.category.findUnique({
-                where: { id: data.categoryId },
-              })
+            ? tx.category.findUnique({ where: { id: data.categoryId } })
             : Promise.resolve(null),
         ]);
 
-        if (!weekPlan) {
-          throw new WeekPlanNotFoundException(weekPlanId);
-        }
-
-        if (data.categoryId && !category) {
+        if (!weekPlan) throw new WeekPlanNotFoundException(weekPlanId);
+        if (data.categoryId && !category)
           throw new CategoryNotFoundException(data.categoryId);
-        }
 
         const parsedDate = new Date(data.date);
-        if (isNaN(parsedDate.getTime())) {
-          throw new InvalidDateException();
-        }
+        if (isNaN(parsedDate.getTime())) throw new InvalidDateException();
 
-        const position = await this.getLastPosition(weekPlanId, data.day);
-
-        const createData: Prisma.TaskCreateInput = {
-          ...data,
+        const position = await this.taskRepository.findLastPosition(
+          weekPlanId,
+          data.day,
+        );
+        const { categoryId, ...restData } = data;
+        const createData = {
+          ...restData,
           position,
           date: parsedDate,
           weekPlan: { connect: { id: weekPlanId } },
-          category: data.categoryId
-            ? { connect: { id: data.categoryId } }
-            : undefined,
+          category: categoryId ? { connect: { id: categoryId } } : undefined,
         };
 
-        const task = await tx.task.create({
-          data: createData,
-          include: {
-            category: {
-              select: { name: true },
-            },
-          },
-        });
-
+        const task = await this.taskRepository.createTask(createData);
         this.websocket.server.emit('taskCreated', task);
 
         if (task.categoryId) {
@@ -112,85 +97,49 @@ export class TasksService {
       if (error instanceof HttpException) {
         throw error;
       }
+      console.log('Error creating task:', error);
       throw new InternalServerErrorException('Failed to create task');
     }
   }
 
   async getTasksForWeek(weekPlanId: string) {
     try {
-      const weekPlan = await this.prisma.weekPlan.findUnique({
-        where: { id: weekPlanId },
-      });
-      if (!weekPlan) {
+      const tasks = await this.taskRepository.findTasksByWeekPlan(weekPlanId);
+      if (!tasks) {
         throw new WeekPlanNotFoundException(weekPlanId);
       }
-
-      return await this.prisma.task.findMany({
-        where: { weekPlanId },
-        include: {
-          category: {
-            select: {
-              name: true,
-            },
-          },
-          weekPlan: true,
-        },
-      });
+      return tasks;
     } catch (error) {
-      if (error instanceof HttpException) {
-        throw error;
-      }
+      if (error instanceof HttpException) throw error;
       throw new InternalServerErrorException('Failed to fetch tasks');
     }
   }
 
   async updateTask(id: string, data: UpdateTaskDto) {
     try {
-      const existingTask = await this.prisma.task.findUnique({
-        where: { id },
-      });
-      if (!existingTask) {
-        throw new TaskNotFoundException(id);
-      }
+      const existingTask = await this.taskRepository.findTaskById(id);
+      if (!existingTask) throw new TaskNotFoundException(id);
 
       if (data.date) {
         const parsedDate = new Date(data.date);
-        if (isNaN(parsedDate.getTime())) {
-          throw new InvalidDateException();
-        }
+        if (isNaN(parsedDate.getTime())) throw new InvalidDateException();
         data.date = parsedDate;
       }
 
       const { categoryId, weekPlanId, ...updateData } = data;
+      const oldTask = await this.taskRepository.findTaskById(id);
 
-      const oldTask = await this.prisma.task.findUnique({
-        where: { id },
-      });
+      const updateTaskData = {
+        ...updateData,
+        ...(categoryId && {
+          category: { connect: { id: categoryId } },
+        }),
+        ...(weekPlanId && {
+          weekPlan: { connect: { id: weekPlanId } },
+        }),
+      };
 
-      const task = await this.prisma.task.update({
-        where: { id },
-        data: {
-          ...updateData,
-          ...(categoryId && {
-            category: {
-              connect: { id: categoryId },
-            },
-          }),
-          ...(weekPlanId && {
-            weekPlan: {
-              connect: { id: weekPlanId },
-            },
-          }),
-        },
-        include: {
-          category: {
-            select: {
-              name: true,
-            },
-          },
-        },
-      });
-
+      const task = await this.taskRepository.updateTask(id, updateTaskData);
       this.websocket.server.emit('taskUpdated', task);
 
       if (oldTask.categoryId) {
@@ -202,34 +151,17 @@ export class TasksService {
 
       return task;
     } catch (error) {
-      console.log(error);
-      if (error instanceof HttpException) {
-        throw error;
-      }
+      if (error instanceof HttpException) throw error;
       throw new InternalServerErrorException('Failed to update task');
     }
   }
 
   async deleteTask(id: string) {
     try {
-      const existingTask = await this.prisma.task.findUnique({
-        where: { id },
-      });
-      if (!existingTask) {
-        throw new TaskNotFoundException(id);
-      }
+      const existingTask = await this.taskRepository.findTaskById(id);
+      if (!existingTask) throw new TaskNotFoundException(id);
 
-      const task = await this.prisma.task.delete({
-        where: { id },
-        include: {
-          category: {
-            select: {
-              name: true,
-            },
-          },
-        },
-      });
-
+      const task = await this.taskRepository.deleteTask(id);
       this.websocket.server.emit('taskDeleted', task);
 
       if (task.categoryId) {
@@ -238,9 +170,7 @@ export class TasksService {
 
       return task;
     } catch (error) {
-      if (error instanceof HttpException) {
-        throw error;
-      }
+      if (error instanceof HttpException) throw error;
       throw new InternalServerErrorException('Failed to delete task');
     }
   }
@@ -307,21 +237,17 @@ export class TasksService {
     try {
       const {
         targetTaskId,
-        position, // теперь число
+        position,
         isArchive,
         archiveReason,
-        day, // destination day
+        day,
         weekPlanId,
       } = moveData;
 
-      return this.prisma.$transaction(async (tx) => {
-        // Проверяем существование задачи
-        const task = await tx.task.findUnique({ where: { id: taskId } });
-        if (!task) {
-          throw new TaskNotFoundException(taskId);
-        }
+      return this.taskRepository.transaction(async (tx) => {
+        const task = await this.taskRepository.findTaskById(taskId);
+        if (!task) throw new TaskNotFoundException(taskId);
 
-        // Обработка архивации/разархивации
         if (isArchive !== undefined) {
           if (isArchive && !task.isArchived) {
             const archivedTask = await this.archiveTask(
@@ -343,44 +269,33 @@ export class TasksService {
           }
         }
 
-        // Если targetTaskId не указан – считаем, что перемещение в пустой день или добавление в конец
         if (!targetTaskId) {
-          const updatedTask = await tx.task.update({
-            where: { id: taskId },
-            data: { day, position },
-            include: { category: { select: { name: true } } },
+          const updatedTask = await this.taskRepository.updateTask(taskId, {
+            day,
+            position,
           });
           this.websocket.server.emit('taskMoved', updatedTask);
           return updatedTask;
         }
 
-        // Если targetTaskId указан, проверяем, не возникнет ли конфликт позиций в целевом дне
         const siblingTasks = await this.getSiblingTasks(tx, day, weekPlanId);
-        // Исключаем перемещаемую задачу (если она уже присутствует)
         const tasksInDestination = siblingTasks.filter((t) => t.id !== taskId);
 
-        // Если уже есть задача с такой позицией, пересчитаем порядок
         const isConflict = tasksInDestination.some(
           (t) => t.position === position,
         );
 
         let newPosition: number;
         if (isConflict) {
-          // Находим индекс target задачи в списке задач нового дня
           const targetIndex = tasksInDestination.findIndex(
             (t) => t.id === targetTaskId,
           );
 
-          // Вставляем перемещаемую задачу в этот список по targetIndex
           const updatedTasks = [...tasksInDestination];
           updatedTasks.splice(targetIndex, 0, task);
-          // Пересчитываем позиции для всех задач целевого дня
           newPosition =
             (updatedTasks.findIndex((t) => t.id === taskId) + 1) * 1000;
 
-          // (Опционально) можно обновить позиции всех задач destination-дня,
-          // чтобы сохранить единообразный порядок.
-          // Например,
           Promise.all(
             updatedTasks.map((t, i) =>
               tx.task.update({
@@ -417,41 +332,15 @@ export class TasksService {
 
   async getArchivedTasks(userId: string) {
     try {
-      return await this.prisma.task.findMany({
-        where: {
-          isArchived: true,
-          category: {
-            userId: userId,
-          },
-        },
-        include: {
-          category: {
-            select: {
-              name: true,
-            },
-          },
-        },
-        orderBy: {
-          archivedAt: 'desc',
-        },
-      });
+      return await this.taskRepository.findArchivedTasks(userId);
     } catch (error) {
-      console.log(error);
       throw new InternalServerErrorException('Failed to fetch archived tasks');
     }
   }
 
   async fixAllPositions() {
     try {
-      // Получаем все неархивированные задачи
-      const tasks = await this.prisma.task.findMany({
-        where: { isArchived: false },
-        // Можно дополнительно отсортировать по weekPlanId и day,
-        // чтобы группировка была более последовательной
-        orderBy: [{ weekPlanId: 'asc' }, { day: 'asc' }, { position: 'asc' }],
-      });
-
-      // Группируем задачи по комбинации weekPlanId и day
+      const tasks = await this.taskRepository.findAllNonArchivedTasks();
       const groupedTasks = tasks.reduce(
         (acc, task) => {
           const key = `${task.weekPlanId}-${task.day}`;
@@ -464,17 +353,13 @@ export class TasksService {
         {} as Record<string, Task[]>,
       );
 
-      // Обновляем позиции для каждой группы
       for (const group of Object.values(groupedTasks)) {
-        // Убедимся, что задачи в группе отсортированы по текущей позиции
         group.sort((a, b) => a.position - b.position);
         let currentPosition = 1000;
-        // Для каждой задачи рассчитываем новую позицию и обновляем её в БД
         const updatePromises = group.map((task) => {
           let pos = currentPosition;
-          const result = this.prisma.task.update({
-            where: { id: task.id },
-            data: { position: pos },
+          const result = this.taskRepository.updateTask(task.id, {
+            position: pos,
           });
           currentPosition += 1000;
 


### PR DESCRIPTION
Refactor the TasksService to use TaskRepository instead of 
PrismaService for task-related database operations. This change 
improves code organization and encapsulates database logic within 
the repository, enhancing maintainability and testability. 
Additionally, it simplifies error handling and reduces direct 
dependencies on the Prisma client.