### PR TITLE
feat: add FocusStatus enum and update WeeklyFocus model

### DIFF
--- a/prisma/migrations/20250329121340_add_focus_status/migration.sql
+++ b/prisma/migrations/20250329121340_add_focus_status/migration.sql
@@ -1,0 +1,5 @@
+-- CreateEnum
+CREATE TYPE "FocusStatus" AS ENUM ('IN_PROGRESS', 'COMPLETED', 'CANCELED');
+
+-- AlterTable
+ALTER TABLE "Focus" ADD COLUMN     "status" "FocusStatus" NOT NULL DEFAULT 'IN_PROGRESS';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -68,11 +68,12 @@ model WeekPlan {
 }
 
 model Focus {
-  id          String   @id @default(uuid()) @db.Uuid
-  weekPlanId  String   @db.Uuid
-  weekPlan    WeekPlan @relation(fields: [weekPlanId], references: [id], onDelete: Cascade)
+  id          String      @id @default(uuid()) @db.Uuid
+  weekPlanId  String      @db.Uuid
+  weekPlan    WeekPlan    @relation(fields: [weekPlanId], references: [id], onDelete: Cascade)
   title       String
   description String
+  status      FocusStatus @default(IN_PROGRESS)
 }
 
 model Category {
@@ -123,4 +124,10 @@ enum TaskStatus {
   TODO
   IN_PROGRESS
   COMPLETED
+}
+
+enum FocusStatus {
+  IN_PROGRESS
+  COMPLETED
+  CANCELED
 }

--- a/src/weekly-focus/dto/update-weekly-focus.dto.ts
+++ b/src/weekly-focus/dto/update-weekly-focus.dto.ts
@@ -1,4 +1,6 @@
 import { CreateWeeklyFocusDto } from './create-weekly-focus.dto';
 import { PartialType } from '@nestjs/mapped-types';
 
-export class UpdateWeeklyFocusDto extends PartialType(CreateWeeklyFocusDto) {}
+export class UpdateWeeklyFocusDto extends PartialType(CreateWeeklyFocusDto) {
+  status?: 'IN_PROGRESS' | 'COMPLETED' | 'CANCELED';
+}

--- a/src/weekly-focus/weekly-focus.service.ts
+++ b/src/weekly-focus/weekly-focus.service.ts
@@ -2,6 +2,7 @@ import { Injectable, NotFoundException } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { CreateWeeklyFocusDto } from './dto/create-weekly-focus.dto';
 import { UpdateWeeklyFocusDto } from './dto/update-weekly-focus.dto';
+import { FocusStatus } from '@prisma/client';
 
 @Injectable()
 export class WeeklyFocusService {
@@ -21,6 +22,7 @@ export class WeeklyFocusService {
       data: {
         title: dto.title,
         description: dto.description || '',
+        status: dto.status || FocusStatus.IN_PROGRESS,
         weekPlanId: weekPlanId,
       },
     });
@@ -67,6 +69,7 @@ export class WeeklyFocusService {
       data: {
         title: dto.title,
         description: dto.description,
+        status: dto.status,
       },
     });
   }


### PR DESCRIPTION
Add a new FocusStatus enum with values IN_PROGRESS, COMPLETED, and 
CANCELED. Update the WeeklyFocus model to include a status field 
defaulting to IN_PROGRESS. Modify the UpdateWeeklyFocusDto to allow 
status updates and adjust the WeeklyFocusService to handle the new 
status field in create and update operations. These changes enhance 
the task management capabilities by allowing for better tracking of 
focus states.