### PR TITLE
feat(dto): add status field to CreateWeeklyFocusDto

### DIFF
--- a/src/weekly-focus/dto/create-weekly-focus.dto.ts
+++ b/src/weekly-focus/dto/create-weekly-focus.dto.ts
@@ -8,4 +8,8 @@ export class CreateWeeklyFocusDto {
   @IsString()
   @IsOptional()
   description?: string;
+
+  @IsString()
+  @IsOptional()
+  status?: 'IN_PROGRESS' | 'COMPLETED' | 'CANCELED';
 }


### PR DESCRIPTION
Add an optional status field to the CreateWeeklyFocusDto to 
track the progress of weekly focuses. The status can be 
'IN_PROGRESS', 'COMPLETED', or 'CANCELED', providing better 
management and clarity on the state of each focus.